### PR TITLE
Update to syntex 0.58.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ doc = false
 path = "src/bin/cheddar.rs"
 
 [dependencies]
-syntex_errors = {version = "0.42.0", optional = true}
-syntex_syntax = {version = "0.42.0", optional = true}
+syntex_errors = {version = "0.58.1", optional = true}
+syntex_syntax = {version = "0.58.1", optional = true}
 toml = "0.3.2"
 clap = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,6 @@ impl Cheddar {
         let result = {
             let mut parser = ::syntax::parse::new_parser_from_source_str(
                 &sess,
-                vec![],
                 "".into(),
                 module.into(),
             );
@@ -526,13 +525,12 @@ impl Cheddar {
     pub fn compile_code(&self) -> Result<String, Vec<Error>> {
         let sess = &self.session;
         let krate = match self.input {
-            Source::File(ref path) => syntax::parse::parse_crate_from_file(path, vec![], sess),
+            Source::File(ref path) => syntax::parse::parse_crate_from_file(path, sess),
             Source::String(ref source) => syntax::parse::parse_crate_from_source_str(
                 "cheddar_source".to_owned(),
                 // TODO: this clone could be quite costly, maybe rethink this design?
                 //     or just use a slice.
                 source.clone(),
-                vec![],
                 sess,
             ),
         }.unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,12 +15,14 @@ pub fn rust_to_c(ty: &ast::Ty, assoc: &str) -> Result<Option<String>, Error> {
         // Special case Options wrapping function pointers.
         ast::TyKind::Path(None, ref path) => {
             if path.segments.len() == 1 &&
-                path.segments[0].identifier.name.as_str() == "Option" {
-                    if let ast::PathParameters::AngleBracketed(ref d) = path.segments[0].parameters {
-                        assert!(d.lifetimes.is_empty() && d.bindings.is_empty());
-                        if d.types.len() == 1 {
-                            if let ast::TyKind::BareFn(ref bare_fn) = d.types[0].node {
-                                return fn_ptr_to_c(bare_fn, ty.span, assoc);
+                path.segments[0].identifier.name == "Option" {
+                    if let Some(ref param) = path.segments[0].parameters {
+                        if let ast::PathParameters::AngleBracketed(ref d) = **param {
+                            assert!(d.lifetimes.is_empty() && d.bindings.is_empty());
+                            if d.types.len() == 1 {
+                                if let ast::TyKind::BareFn(ref bare_fn) = d.types[0].node {
+                                    return fn_ptr_to_c(bare_fn, ty.span, assoc);
+                                }
                             }
                         }
                     }
@@ -263,7 +265,6 @@ mod test {
         let result = {
             let mut parser = ::syntax::parse::new_parser_from_source_str(
                 &sess,
-                vec![],
                 "".into(),
                 source.into(),
             );


### PR DESCRIPTION
Update to the current version of syntex.  I hoped this would make it easier to fix the without-syntex nightly-only build, but it doesn't because syntex is currently incompatible with rustc nightly (https://github.com/serde-rs/syntex/issues/117), and may remain so now that syntex is maintainerless (https://github.com/serde-rs/syntex/issues/114).

I don't know if this PR helps with https://github.com/mozilla/moz-cheddar/issues/3 at all, but clearly moving to syn is the way forward.